### PR TITLE
#166789829 Integrate code climate and test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,27 @@
-version: 2.1
+version: 2
 jobs:
   build:
+    environment:
+      CC_TEST_REPORTER_ID: 54210b60f354d1fcd02e9bf334196b3eaab6a9709cd86172953a08552bc368b0
     docker:
-      - image: alpine:3.7
+      - image: circleci/node:7.10
     steps:
+      - checkout
+      - run: npm install
+      - run: npm test
       - run:
-          name: The First Step
+          name: Setup Code Climate test-reporter
           command: |
-            echo 'Hello World!'
-            echo 'This is the delivery pipeline'
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+
+      - run:
+          name: Run tests
+          command: |
+            ./cc-test-reporter before-build
+             # upload test report to Code Climate using `after-build`.
+            ./cc-test-reporter after-build
+
+      - store_artifacts:
+          path: coverage
+          destination: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ cypress/fixtures/
 cypress/plugins/
 cypress/support/
 cypress/videos/
+
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,7 @@ script:
     - 'export CYPRESS_CACHE_FOLDER=../../cache/Cypress'
     - 'export CYPRESS_CACHE_FOLDER=cache/Cypress'
     - npm test
+after_success:
+  - 
 notifications:
-  email: false  
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## ah-lobos-frontend [![Build Status](https://travis-ci.com/andela/ah-lobos-frontend.svg?branch=develop)](https://travis-ci.com/andela/ah-lobos-frontend)
+## ah-lobos-frontend [![Build Status](https://travis-ci.com/andela/ah-lobos-frontend.svg?branch=develop)](https://travis-ci.com/andela/ah-lobos-frontend) [![Maintainability](https://api.codeclimate.com/v1/badges/2be87cd7dd91c6183243/maintainability)](https://codeclimate.com/github/andela/ah-lobos-frontend/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/2be87cd7dd91c6183243/test_coverage)](https://codeclimate.com/github/andela/ah-lobos-frontend/test_coverage)
 
 A Social platform for the creative at heart.
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
     "cypress": "cypress open",
     "cypress:all": "cypress run",
+    "test": "jest --coverage",
     "start": "webpack-dev-server --mode development --open --hot",
     "build": "webpack --mode production"
   },

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,3 +1,0 @@
-test("Travis test", () => {
-  expect(true).toBeTruthy();
-});


### PR DESCRIPTION
#### What does this PR do?

 - Run code climate test coverage

#### Description of Task to be completed?

  - Run code climate test coverage after passing the tests from circleci

#### How should this be manually tested?

 -  When a PR(Pull request) is raised, CircleCi will automatically start to build and testing after the success it will pass a report to code climate. With code climate, you will be able to see maintainability and test coverage.

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- [#166789829](https://www.pivotaltracker.com/story/show/166789829)

#### Screenshots (if appropriate)

- Our repo integrated on code climate

![image](https://user-images.githubusercontent.com/48624152/63217779-b29fc080-c14c-11e9-893a-b56d755dcf86.png)

- CircleCi builds the branch

![image](https://user-images.githubusercontent.com/48624152/63217786-d5ca7000-c14c-11e9-8783-235c5db92ffe.png)

- All the badges added

![image](https://user-images.githubusercontent.com/48624152/63217808-1f1abf80-c14d-11e9-886d-75c6f8d4f319.png)

#### Questions:

- N/A